### PR TITLE
Update .travis.yml to replace 'master' with 'main' for Go version com…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - 1.11
-  - master
+  - main
 
 env:
   - GO111MODULE=on
@@ -10,7 +10,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-  - go: master
+  - go: main
 
 script:
   - make all


### PR DESCRIPTION
This PR updates default branch references from "master" and "flatcar-master" to "main" to align with modern Git conventions and inclusive naming practices.

This pull request updates the Go language version configuration in the `.travis.yml` file to reflect a branch name change from `master` to `main`.

* [`.travis.yml`](diffhunk://#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485L5-R13): Replaced references to the `master` branch with `main` in the Go version matrix and the `allow_failures` section.

In reference to https://github.com/flatcar/Flatcar/issues/1714